### PR TITLE
Fix teleportation towers providing a cloak field

### DIFF
--- a/units/BAA0309/BAA0309_Script.lua
+++ b/units/BAA0309/BAA0309_Script.lua
@@ -2,7 +2,7 @@
 -- File     :  /cdimage/units/BAA0309/BAA0309_script.lua
 -- Author(s):  John Comes, David Tomandl, Jessica St. Croix, Gordon Duclos
 -- Summary  :  Aeon T2 Transport Script
--- Copyright � 2006 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
 --------------------------------------------------------------------------
 
 local AirTransport = import('/lua/defaultunits.lua').AirTransport

--- a/units/BAA0309/BAA0309_Script.lua
+++ b/units/BAA0309/BAA0309_Script.lua
@@ -2,7 +2,7 @@
 -- File     :  /cdimage/units/BAA0309/BAA0309_script.lua
 -- Author(s):  John Comes, David Tomandl, Jessica St. Croix, Gordon Duclos
 -- Summary  :  Aeon T2 Transport Script
--- Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright ï¿½ 2006 Gas Powered Games, Inc.  All rights reserved.
 --------------------------------------------------------------------------
 
 local AirTransport = import('/lua/defaultunits.lua').AirTransport
@@ -40,7 +40,9 @@ BAA0309 = Class(AirTransport) {
 
     OnStopBeingBuilt = function(self,builder,layer)
         AirTransport.OnStopBeingBuilt(self,builder,layer)
-        self:DisableUnitIntel('unitScript', 'CloakField') -- It's only used to denote the Tele range
+
+        -- only used to show teleport range
+        self:DisableIntel('CloakField')
     end,
 }
 

--- a/units/BAB4209/BAB4209_script.lua
+++ b/units/BAB4209/BAB4209_script.lua
@@ -2,7 +2,7 @@
 -- File     :  /cdimage/units/BAB4209/BAB4209_script.lua
 -- Author(s):  John Comes, Dave Tomandl, Jessica St. Croix
 -- Summary  :  Aeon Power Generator Script
--- Copyright � 1205 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright © 1205 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
 local AStructureUnit = import('/lua/aeonunits.lua').AStructureUnit

--- a/units/BAB4209/BAB4209_script.lua
+++ b/units/BAB4209/BAB4209_script.lua
@@ -2,7 +2,7 @@
 -- File     :  /cdimage/units/BAB4209/BAB4209_script.lua
 -- Author(s):  John Comes, Dave Tomandl, Jessica St. Croix
 -- Summary  :  Aeon Power Generator Script
--- Copyright © 1205 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright ï¿½ 1205 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
 local AStructureUnit = import('/lua/aeonunits.lua').AStructureUnit
@@ -21,7 +21,10 @@ BAB4209 = Class(AStructureUnit) {
     OnStopBeingBuilt = function(self,builder,layer)
         AStructureUnit.OnStopBeingBuilt(self,builder,layer)
         self:SetScriptBit('RULEUTC_ShieldToggle', true)
-        self:DisableUnitIntel('unitScript', 'CloakField') -- Used to show anti-tele range
+
+        -- only used to show anti-teleport range
+        self:DisableIntel('CloakField')
+
         self.AmbientEffectsBag = {}
         self.antiteleportEmitterTable = {}
         self:ForkThread(self.ResourceThread)

--- a/units/BAB4309/BAB4309_script.lua
+++ b/units/BAB4309/BAB4309_script.lua
@@ -2,7 +2,7 @@
 -- File     :  /cdimage/units/BAB4309/BAB4309_script.lua
 -- Author(s):  John Comes, Dave Tomandl, Jessica St. Croix
 -- Summary  :  Aeon Power Generator Script
--- Copyright © 1205 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright ï¿½ 1205 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
 local AStructureUnit = import('/lua/aeonunits.lua').AStructureUnit
@@ -21,7 +21,8 @@ BAB4309 = Class(AStructureUnit) {
     OnStopBeingBuilt = function(self,builder,layer)
         AStructureUnit.OnStopBeingBuilt(self,builder,layer)
         self:SetScriptBit('RULEUTC_ShieldToggle', true)
-        self:DisableUnitIntel('unitScript', 'CloakField') -- Used to show anti-tele range
+        -- only used to show anti-teleport range
+        self:DisableIntel('CloakField')
         self.AntiTeleportEffectsBag = {}
         self.AmbientEffectsBag = {}
         self.antiteleportEmitterTable = {}

--- a/units/BAB4309/BAB4309_script.lua
+++ b/units/BAB4309/BAB4309_script.lua
@@ -2,7 +2,7 @@
 -- File     :  /cdimage/units/BAB4309/BAB4309_script.lua
 -- Author(s):  John Comes, Dave Tomandl, Jessica St. Croix
 -- Summary  :  Aeon Power Generator Script
--- Copyright � 1205 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright © 1205 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
 local AStructureUnit = import('/lua/aeonunits.lua').AStructureUnit

--- a/units/BEB4209/BEB4209_script.lua
+++ b/units/BEB4209/BEB4209_script.lua
@@ -2,7 +2,7 @@
 -- File     :  /cdimage/units/XEB4309/XEB4309_script.lua
 -- Author(s):  David Tomandl, Jessica St. Croix
 -- Summary  :  UEF Radar Jammer Script
--- Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright ï¿½ 2005 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
 local TStructureUnit = import('/lua/terranunits.lua').TStructureUnit
@@ -16,7 +16,8 @@ BEB4209 = Class(TStructureUnit) {
     OnStopBeingBuilt = function(self,builder,layer)
         TStructureUnit.OnStopBeingBuilt(self,builder,layer)
         self:SetScriptBit('RULEUTC_ShieldToggle', true)
-        self:DisableUnitIntel('unitScript', 'CloakField') -- Used to show anti-tele range
+        -- only used to show anti-teleport range
+        self:DisableIntel('CloakField')
         self.antiteleportEmitterTable = {}
         self.AntiTeleportBag = {}
         self:ForkThread(self.ResourceThread)

--- a/units/BEB4209/BEB4209_script.lua
+++ b/units/BEB4209/BEB4209_script.lua
@@ -2,7 +2,7 @@
 -- File     :  /cdimage/units/XEB4309/XEB4309_script.lua
 -- Author(s):  David Tomandl, Jessica St. Croix
 -- Summary  :  UEF Radar Jammer Script
--- Copyright � 2005 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
 local TStructureUnit = import('/lua/terranunits.lua').TStructureUnit

--- a/units/BEB4309/BEB4309_script.lua
+++ b/units/BEB4309/BEB4309_script.lua
@@ -2,7 +2,7 @@
 -- File     :  /cdimage/units/XEB4309/XEB4309_script.lua
 -- Author(s):  David Tomandl, Jessica St. Croix
 -- Summary  :  UEF Radar Jammer Script
--- Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright ï¿½ 2005 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
 local TStructureUnit = import('/lua/terranunits.lua').TStructureUnit
@@ -16,7 +16,8 @@ BEB4309 = Class(TStructureUnit) {
     OnStopBeingBuilt = function(self,builder,layer)
         TStructureUnit.OnStopBeingBuilt(self,builder,layer)
         self:SetScriptBit('RULEUTC_ShieldToggle', true)
-        self:DisableUnitIntel('unitScript', 'CloakField') -- Used to show anti-tele range
+        -- only used to show anti-teleport range
+        self:DisableIntel('CloakField')
         self.antiteleportEmitterTable = {}
         self.AntiTeleportBag = {}
         self:ForkThread(self.ResourceThread)

--- a/units/BEB4309/BEB4309_script.lua
+++ b/units/BEB4309/BEB4309_script.lua
@@ -2,7 +2,7 @@
 -- File     :  /cdimage/units/XEB4309/XEB4309_script.lua
 -- Author(s):  David Tomandl, Jessica St. Croix
 -- Summary  :  UEF Radar Jammer Script
--- Copyright � 2005 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
 local TStructureUnit = import('/lua/terranunits.lua').TStructureUnit

--- a/units/BRB4209/BRB4209_script.lua
+++ b/units/BRB4209/BRB4209_script.lua
@@ -2,7 +2,7 @@
 -- File     :  /cdimage/units/XRB4309/XRB4309_script.lua
 -- Author(s):  David Tomandl, Greg Kohne
 -- Summary  :  Cybran Shield Generator lvl 5 Script
--- Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright ï¿½ 2007 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
 local CStructureUnit = import('/lua/cybranunits.lua').CStructureUnit
@@ -12,7 +12,8 @@ BRB4209 = Class(CStructureUnit) {
     OnStopBeingBuilt = function(self,builder,layer)
         CStructureUnit.OnStopBeingBuilt(self,builder,layer)
         self:SetScriptBit('RULEUTC_ShieldToggle', true)
-        self:DisableUnitIntel('unitScript', 'CloakField') -- Used to show anti-tele range
+        -- only used to show anti-teleport range
+        self:DisableIntel('CloakField')
         self.antiteleportEmitterTable = {}
         self:ForkThread(self.ResourceThread)
     end,

--- a/units/BRB4209/BRB4209_script.lua
+++ b/units/BRB4209/BRB4209_script.lua
@@ -2,7 +2,7 @@
 -- File     :  /cdimage/units/XRB4309/XRB4309_script.lua
 -- Author(s):  David Tomandl, Greg Kohne
 -- Summary  :  Cybran Shield Generator lvl 5 Script
--- Copyright � 2007 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
 local CStructureUnit = import('/lua/cybranunits.lua').CStructureUnit

--- a/units/BRB4309/BRB4309_script.lua
+++ b/units/BRB4309/BRB4309_script.lua
@@ -2,7 +2,7 @@
 -- File     :  /cdimage/units/XRB4309/XRB4309_script.lua
 -- Author(s):  David Tomandl, Greg Kohne
 -- Summary  :  Cybran Shield Generator lvl 5 Script
--- Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright ï¿½ 2007 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
 local CStructureUnit = import('/lua/cybranunits.lua').CStructureUnit
@@ -17,7 +17,8 @@ BRB4309 = Class(CStructureUnit) {
     OnStopBeingBuilt = function(self,builder,layer)
         CStructureUnit.OnStopBeingBuilt(self,builder,layer)
         self:SetScriptBit('RULEUTC_ShieldToggle', true)
-        self:DisableUnitIntel('unitScript', 'CloakField') -- Used to show anti-tele range
+        -- only used to show anti-teleport range
+        self:DisableIntel('CloakField')
         self.antiteleportEmitterTable = {}
         self:ForkThread(self.ResourceThread)
     end,

--- a/units/BRB4309/BRB4309_script.lua
+++ b/units/BRB4309/BRB4309_script.lua
@@ -2,7 +2,7 @@
 -- File     :  /cdimage/units/XRB4309/XRB4309_script.lua
 -- Author(s):  David Tomandl, Greg Kohne
 -- Summary  :  Cybran Shield Generator lvl 5 Script
--- Copyright � 2007 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
 local CStructureUnit = import('/lua/cybranunits.lua').CStructureUnit

--- a/units/BSB4205/BSB4205_script.lua
+++ b/units/BSB4205/BSB4205_script.lua
@@ -2,7 +2,7 @@
 -- File     :  /cdimage/units/XSB4205/XSB4205_script.lua
 -- Author(s):  Dru Staltman
 -- Summary  :  Seraphim T2 Power Generator Script
--- Copyright � 2005 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
 local SStructureUnit = import('/lua/seraphimunits.lua').SStructureUnit

--- a/units/BSB4205/BSB4205_script.lua
+++ b/units/BSB4205/BSB4205_script.lua
@@ -2,7 +2,7 @@
 -- File     :  /cdimage/units/XSB4205/XSB4205_script.lua
 -- Author(s):  Dru Staltman
 -- Summary  :  Seraphim T2 Power Generator Script
--- Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright ï¿½ 2005 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
 local SStructureUnit = import('/lua/seraphimunits.lua').SStructureUnit
@@ -31,7 +31,8 @@ BSB4205 = Class(SStructureUnit) {
     OnStopBeingBuilt = function(self,builder,layer)
         SStructureUnit.OnStopBeingBuilt(self,builder,layer)
         self:SetMaintenanceConsumptionActive()
-        self:DisableUnitIntel('unitScript', 'CloakField') -- Used to show restoration range
+        -- only used to show restoration range
+        self:DisableIntel('CloakField')
         if not self.ShieldEffectsBag then
             self.ShieldEffectsBag = {}
         end

--- a/units/BSB4209/BSB4209_script.lua
+++ b/units/BSB4209/BSB4209_script.lua
@@ -2,7 +2,7 @@
 -- File     :  /data/units/BSB4209/BSB4209_script.lua
 -- Author(s):  Jessica St. Croix
 -- Summary  :  Seraphim T3 Radar Tower Script
--- Copyright � 2007 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
 local SStructureUnit = import('/lua/seraphimunits.lua').SStructureUnit

--- a/units/BSB4209/BSB4209_script.lua
+++ b/units/BSB4209/BSB4209_script.lua
@@ -2,7 +2,7 @@
 -- File     :  /data/units/BSB4209/BSB4209_script.lua
 -- Author(s):  Jessica St. Croix
 -- Summary  :  Seraphim T3 Radar Tower Script
--- Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright ï¿½ 2007 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
 local SStructureUnit = import('/lua/seraphimunits.lua').SStructureUnit
@@ -16,7 +16,8 @@ BSB4209 = Class(SStructureUnit) {
     OnStopBeingBuilt = function(self,builder,layer)
         SStructureUnit.OnStopBeingBuilt(self,builder,layer)
         self:SetScriptBit('RULEUTC_ShieldToggle', true)
-        self:DisableUnitIntel('unitScript', 'CloakField') -- Used to show anti-tele range
+        -- only used to show anti-teleport range
+        self:DisableIntel('CloakField')
         self.antiteleportEmitterTable = {}
         self.AntiTeleportBag = {}
         self:ForkThread(self.ResourceThread)

--- a/units/BSB4309/BSB4309_script.lua
+++ b/units/BSB4309/BSB4309_script.lua
@@ -2,7 +2,7 @@
 -- File     :  /data/units/BSB4309/BSB4309_script.lua
 -- Author(s):  Jessica St. Croix
 -- Summary  :  Seraphim T3 Radar Tower Script
--- Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright ï¿½ 2007 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
 local SStructureUnit = import('/lua/seraphimunits.lua').SStructureUnit
@@ -20,7 +20,8 @@ BSB4309 = Class(SStructureUnit) {
     OnStopBeingBuilt = function(self,builder,layer)
         SStructureUnit.OnStopBeingBuilt(self,builder,layer)
         self:SetScriptBit('RULEUTC_ShieldToggle', true)
-        self:DisableUnitIntel('unitScript', 'CloakField') -- Used to show anti-tele range
+        -- only used to show anti-teleport range
+        self:DisableIntel('CloakField')
         self.antiteleportEmitterTable = {}
         self.AntiTeleportBag = {}
         self.AntiTeleportOrbsBag = {}

--- a/units/BSB4309/BSB4309_script.lua
+++ b/units/BSB4309/BSB4309_script.lua
@@ -2,7 +2,7 @@
 -- File     :  /data/units/BSB4309/BSB4309_script.lua
 -- Author(s):  Jessica St. Croix
 -- Summary  :  Seraphim T3 Radar Tower Script
--- Copyright � 2007 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
 local SStructureUnit = import('/lua/seraphimunits.lua').SStructureUnit


### PR DESCRIPTION
We bypass the intel system introduced by [Game version 3751](https://github.com/FAForever/fa/releases/tag/3751) as they have nothing to do with intel. Instead it should've used the same system that the Cybran Soothsayer uses to indicate a range. 

Bug fix initiated from the FAF forums, see also:

- https://forum.faforever.com/topic/353/blackopsfaf-unleashed-only-for-faf-v20/79