### PR TITLE
Fix teleport for tech 3 Aeon transport

### DIFF
--- a/units/BAA0309/BAA0309_Script.lua
+++ b/units/BAA0309/BAA0309_Script.lua
@@ -2,7 +2,7 @@
 -- File     :  /cdimage/units/BAA0309/BAA0309_script.lua
 -- Author(s):  John Comes, David Tomandl, Jessica St. Croix, Gordon Duclos
 -- Summary  :  Aeon T2 Transport Script
--- Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright ï¿½ 2006 Gas Powered Games, Inc.  All rights reserved.
 --------------------------------------------------------------------------
 
 local AirTransport = import('/lua/defaultunits.lua').AirTransport
@@ -24,6 +24,13 @@ BAA0309 = Class(AirTransport) {
         SonicPulseBattery3 = Class(AAASonicPulseBatteryWeapon) {},
         SonicPulseBattery4 = Class(AAASonicPulseBatteryWeapon) {},
     },
+
+    OnCreate = function(self)
+        AirTransport.OnCreate(self)
+
+        -- allow this unit to teleport
+        self:AddCommandCap('RULEUCC_Teleport')
+    end,
 
     -- Override air destruction effects so we can do something custom here
     CreateUnitAirDestructionEffects = function(self, scale)

--- a/units/BAA0309/BAA0309_Script.lua
+++ b/units/BAA0309/BAA0309_Script.lua
@@ -2,7 +2,7 @@
 -- File     :  /cdimage/units/BAA0309/BAA0309_script.lua
 -- Author(s):  John Comes, David Tomandl, Jessica St. Croix, Gordon Duclos
 -- Summary  :  Aeon T2 Transport Script
--- Copyright � 2006 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
 --------------------------------------------------------------------------
 
 local AirTransport = import('/lua/defaultunits.lua').AirTransport


### PR DESCRIPTION
Adds the command cap manually. The engine version to check the command caps has been bugged since forever. We introduced the check to guarantee the player has the command capabilities to prevent cheating.

Bug fix initiated from the FAF forums, see also:

- https://forum.faforever.com/topic/353/blackopsfaf-unleashed-only-for-faf-v20/79