### PR TITLE
added dummy weapon to attack enemies directly below.

### DIFF
--- a/Bugfix by Uveso.md
+++ b/Bugfix by Uveso.md
@@ -4,6 +4,7 @@
 - Added Annotations (MrRowey)
 - Speed up functions (MrRowey)
 - Fixed CreateProjectileAtMuzzle hooks by returning the projectile to parent function
+- Unit bea0402 (Experimental Aerial Fortress) now has a dummy weapon to attack enemies directly below.
 
 ---
 

--- a/units/BEA0402/BEA0402_script.lua
+++ b/units/BEA0402/BEA0402_script.lua
@@ -13,10 +13,12 @@ local CitadelHVMWeapon = import('/mods/BlackOpsFAF-Unleashed/lua/BlackOpsWeapons
 local CitadelPlasmaGatlingCannonWeapon = import('/mods/BlackOpsFAF-Unleashed/lua/BlackOpsWeapons.lua').CitadelPlasmaGatlingCannonWeapon
 local EffectUtils = import('/lua/effectutilities.lua')
 local Effects = import('/lua/effecttemplates.lua')
+local DummyWeapon = import("/lua/aeonweapons.lua").AAASonicPulseBatteryWeapon
 
 ---@class BEA0402 : TAirUnit
 BEA0402 = Class(TAirUnit) {
     Weapons = {
+        GuidanceSystem = ClassWeapon(DummyWeapon) {},
         MainTurret01 = Class(RailGunWeapon02) {},
         MainTurret02 = Class(RailGunWeapon02) {},
         HVMTurret01 = Class(CitadelHVMWeapon) {},

--- a/units/BEA0402/BEA0402_unit.bp
+++ b/units/BEA0402/BEA0402_unit.bp
@@ -16,8 +16,8 @@ UnitBlueprint {
         },
     },
     Air = {
-        BankFactor = 0,
-        BankForward = false,
+        BankFactor = 0.1,
+        BankForward = true,
         CanFly = true,
         CirclingDirChange = false,
         CirclingElevationChangeRatio = 0.1,
@@ -289,6 +289,33 @@ UnitBlueprint {
     VeteranMassMult = 0.5,
     Weapon = {
         {
+            Damage = 0,
+            DisplayName = "Weapon Guidance System",
+            FireTargetLayerCapsTable = {
+                Air = "Land|Water|Seabed",
+                Land = "Land|Water|Seabed",
+            },
+            Label = "GuidanceSystem",
+            MaxRadius = 40,
+            MuzzleSalvoDelay = 1,
+            MuzzleSalvoSize = 0,
+            ProjectileId = "/projectiles/AAASonicPulse02/AAASonicPulse02_proj.bp",
+            RackBones = {
+                {
+                    MuzzleBones = { "Muzzle_R" },
+                    RackBone = "Turret_Right",
+                },
+            },
+            RackRecoilDistance = 0,
+            TargetRestrictDisallow = "UNTARGETABLE AIR",
+            TurretPitch = 0,
+            TurretPitchRange = 45,
+            TurretPitchSpeed = 360,
+            TurretYaw = 0,
+            TurretYawRange = 180,
+            TurretYawSpeed = 360,
+        },
+        {
             AboveWaterFireOnly = true,
             AboveWaterTargetsOnly = true,
             Audio = {
@@ -374,10 +401,10 @@ UnitBlueprint {
             TurretBoneYaw = 'Railgun_Turret_1',
             TurretDualManipulators = false,
             TurretPitch = 0, -- Horizontal, bones are orientated incorrectly
-            TurretPitchRange = 150,
+            TurretPitchRange = 360,
             TurretPitchSpeed = 40,
             TurretYaw = 0, -- Vertical, bones are orientated incorrectly
-            TurretYawRange = 70,
+            TurretYawRange = 360,
             TurretYawSpeed = 40,
             Turreted = true,
             WeaponCategory = 'Direct Fire',


### PR DESCRIPTION
The Citadel MKII now includes a dummy weapon to fix issues where the unit would move directly above enemies, preventing its cannons from aiming or firing properly. This dummy weapon ensures correct unit behavior, accounting for the Gauss cannons being mounted at a tilted angle on the sides.